### PR TITLE
InvalidAccessTokenException body constructor parameter should be optional.

### DIFF
--- a/src/SpiffyConnect/Client/Exception/InvalidAccessTokenException.php
+++ b/src/SpiffyConnect/Client/Exception/InvalidAccessTokenException.php
@@ -14,13 +14,13 @@ class InvalidAccessTokenException extends Exception\InvalidArgumentException
 
     /**
      * @param string $msg
-     * @param int $body
+     * @param string $body
      * @param int $code
      * @param \Exception $previous
      */
     public function __construct(
         $msg = "the specified access token is invalid",
-        $body,
+        $body = "",
         $code = 0,
         \Exception $previous = null
     ) {


### PR DESCRIPTION
Fixes Issue #1

https://github.com/spiffyjr/spiffy-connect/issues/1
